### PR TITLE
include openssh-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update \
     python3-pkg-resources \
     python3-pygments \
     imagemagick \
+    # @see https://secure.phabricator.com/w/guides/dependencies/
+    # provides ssh-keygen and ssh, these are needed to sync ssh repositories
+    openssh-client \
     procps \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.aphlict
+++ b/Dockerfile.aphlict
@@ -14,6 +14,9 @@ RUN apt-get update \
     python3-pkg-resources \
     python3-pygments \
     imagemagick \
+    # @see https://secure.phabricator.com/w/guides/dependencies/
+    # provides ssh-keygen and ssh, these are needed to sync ssh repositories
+    openssh-client \
     procps \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -14,6 +14,9 @@ RUN apt-get update \
     python3-pkg-resources \
     python3-pygments \
     imagemagick \
+    # @see https://secure.phabricator.com/w/guides/dependencies/
+    # provides ssh-keygen and ssh, these are needed to sync ssh repositories
+    openssh-client \
     procps \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This is needed if you want to mirror ssh-repositories and import private keys

For the stable branch